### PR TITLE
Avoid rollback to avoid losing chess game state.

### DIFF
--- a/game/script.rpy
+++ b/game/script.rpy
@@ -47,8 +47,17 @@ label start:
     window hide
     $ quick_menu = False
 
+    # avoid rolling back and losing chess game state
+    $ renpy.block_rollback()
+
     $ fen = chess.STARTING_FEN
     call screen chess(fen, player_color, movetime, depth)
+
+    # avoid rolling back and entering the chess game again
+    $ renpy.block_rollback()
+
+    # restore rollback from this point on
+    $ renpy.checkpoint()
 
     $ quick_menu = True
     window show


### PR DESCRIPTION
Attempt to fix ['[Bug] Scrolling moves to previous screen and resets game"](https://trello.com/c/VdBWDEmJ)  by blocking rollbacks right before the chess screen is shown, then after it returns (to avoid rolling back into the chess game). Only tested in Windows.

Open to and welcoming any suggestions, criticisms, alternative designs and requests.

Thank you for this cool project! I hope to be able to help more!